### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/nuruddeensalis/9dd400d0-e0aa-4ff4-910a-7dab641db496/876322d2-1200-4e8d-8fce-1ac80e02aa2d/_apis/work/boardbadge/185d0ab9-e29b-4171-b37c-c111497febc0)](https://dev.azure.com/nuruddeensalis/9dd400d0-e0aa-4ff4-910a-7dab641db496/_boards/board/t/876322d2-1200-4e8d-8fce-1ac80e02aa2d/Microsoft.RequirementCategory)
 ## GitHub Docs <!-- omit in toc -->
 
 This repository contains the documentation website code and Markdown source files for docs.github.com.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/nuruddeensalis/9dd400d0-e0aa-4ff4-910a-7dab641db496/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.